### PR TITLE
Create unsolved package handler workflow template for adviser workflow

### DIFF
--- a/openshift/unresolved-package-handler-job-template.yaml
+++ b/openshift/unresolved-package-handler-job-template.yaml
@@ -30,12 +30,6 @@ parameters:
     name: IMAGE_STREAM_REGISTRY
     value: "docker-registry.default.svc:5000"
 
-  - displayName: Suspend CronJob run
-    description: Suspend CronJob run
-    required: true
-    name: THOTH_SUSPEND_JOB
-    value: "true"
-
   - description: Project the ImageStream to be use lives in
     displayName: ImageStream Project
     required: true

--- a/workflows/templates/unresolved-package-handler-template.yaml
+++ b/workflows/templates/unresolved-package-handler-template.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: unresolved-package-handler
+  annotations:
+    thoth-station.ninja/template-version: 0.1.0
+  labels:
+    app: thoth
+    component: unresolved-package-handler
+
+spec:
+  templates:
+    - name: unresolved-package-handler
+      inputs:
+        parameters:
+          - name: THOTH_DOCUMENT_ID
+          - name: "IMAGE_STREAM_REGISTRY"
+          - name: "IMAGE_STREAM_NAMESPACE"
+          - name: "IMAGE_STREAM_TAG"
+        artifacts:
+          - name: "outputdocument"
+            path: "/mnt/component/document/{{inputs.parameters.THOTH_DOCUMENT_ID}}"
+      container:
+        name: unresolved-package-handler
+        image: "{{inputs.parameters.IMAGE_STREAM_REGISTRY}}/\
+        {{inputs.parameters.IMAGE_STREAM_NAMESPACE}}/\
+        unresolved-package-handler:{{inputs.parameters.IMAGE_STREAM_TAG}}"
+        env:
+          - name: JSON_FILE_PATH
+            value: "/mnt/component/document/{{inputs.parameters.THOTH_DOCUMENT_ID}}"
+          - name: SUBCOMMAND
+            value: "producer"
+          - name: DEBUG_LEVEL
+            value: "0"
+          - name: APP_SCRIPT
+            value: "app.sh"
+          - name: KAFKA_BOOTSTRAP_SERVERS
+            valueFrom:
+              configMapKeyRef:
+                key: kafka-bootstrap-servers
+                name: thoth
+          - name: KAFKA_CLIENT_ID
+            valueFrom:
+              configMapKeyRef:
+                key: kafka-client-id
+                name: thoth
+          - name: KAFKA_SSL_AUTH
+            valueFrom:
+              configMapKeyRef:
+                key: kafka-ssl-auth
+                name: thoth
+          - name: KAFKA_RETENTION_TIME_SECONDS
+            valueFrom:
+              configMapKeyRef:
+                key: kafka-topic-retention-time
+                name: thoth
+          - name: KAFKA_CAFILE
+            value: "/mnt/secrets/kafka_ca.crt"
+        volumeMounts:
+          - name: secrets
+            mountPath: /mnt/secrets
+        resources:
+          limits:
+            cpu: 250m
+            memory: 256Mi
+          requests:
+            cpu: 250m
+            memory: 256Mi


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

Related-to: https://github.com/thoth-station/adviser/issues/984

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

- Introduce WorkflowTemplate to run in adviser workflow
- Introduce Job to run the single task

- Tested successfully
